### PR TITLE
BUGFIX: did not properly refer to namespace prefix when copying namespaces

### DIFF
--- a/src/main/java/org/wiztools/xsdgen/XsdGen.java
+++ b/src/main/java/org/wiztools/xsdgen/XsdGen.java
@@ -147,7 +147,7 @@ public final class XsdGen {
             for (int i = 0; i < rootElement.getNamespaceDeclarationCount(); i++) {
                 final String nsPrefix2 = rootElement.getNamespacePrefix(i);
                 final String nsURI = rootElement.getNamespaceURI(nsPrefix2);
-                outRoot.addNamespaceDeclaration(nsPrefix, nsURI);
+                outRoot.addNamespaceDeclaration(nsPrefix2, nsURI);
             }
 
             // adding the root element


### PR DESCRIPTION
When trying to generate XSD from instance, XsdGen barfed on:

<SetGroupageServiceStatusRequest
      xmlns="http://www.psv3.de/Server/Interfaces/Xml/MessageTypes"
      xmlns:psv3processtypes="http://www.psv3.de/Server/Interfaces/Xml/ProcessTypes" 
      ...

XsdGen did not use prefix "psv3processtypes" when adding second namespace ProcessTypes,  instead referring to the global 'nsPrefix' (instead of nsPrefix2).
